### PR TITLE
Patch modules bug fix

### DIFF
--- a/handlers/helpers.go
+++ b/handlers/helpers.go
@@ -67,3 +67,12 @@ func renderErrors(c *gin.Context, errs []error) {
 		}(errs),
 	})
 }
+
+func contains(slice []int, id int) bool {
+	for _, num := range slice {
+		if num == id {
+			return true
+		}
+	}
+	return false
+}

--- a/models/module_activity.go
+++ b/models/module_activity.go
@@ -7,7 +7,7 @@ type ModuleActivity struct {
 	Input                int       `json:"input"`
 	Notes                string    `json:"notes"`
 	ModuleId             int       `json:"-"`
-	CreatedAt, UpdatedAt time.Time `json:"-" gorm:"type:timestamp;default:CURRENT_TIMESTAMP"`
 	ActivityId           int       `json:"activityId"`
+	CreatedAt, UpdatedAt time.Time `json:"-" gorm:"type:timestamp;default:CURRENT_TIMESTAMP"`
 	Activity             Activity  `json:"activity"`
 }

--- a/testing/patch_modules_test.go
+++ b/testing/patch_modules_test.go
@@ -22,11 +22,13 @@ func TestPATCHModule(t *testing.T) {
 		var moduleCount int64
 		config.Conn.Model(models.Module{}).Count(&moduleCount)
 
+		var moduleActivityCount int64
+		config.Conn.Model(models.ModuleActivity{}).Count(&moduleActivityCount)
+
 		newModuleInfo := `{
 			"name": "new module name",
 			"moduleActivities":[
 				{
-					"id": 1,
 					"input": 30,
 					"notes": "A new note",
 					"activityId": 1
@@ -43,10 +45,17 @@ func TestPATCHModule(t *testing.T) {
 		assertResponseValue(t, parsedResponse.Message, "Module updated successfully", "Message")
 
 		var newCount int64
-		config.Conn.Model(models.Course{}).Count(&newCount)
+		config.Conn.Model(models.Module{}).Count(&newCount)
 
 		if newCount != moduleCount {
 			t.Errorf("patch request should not have changed module count but did")
+		}
+
+		var newModActivityCount int64
+		config.Conn.Model(models.ModuleActivity{}).Count(&newModActivityCount)
+
+		if newModActivityCount != moduleActivityCount {
+			t.Errorf("added a new module activity but should not have")
 		}
 
 		var updatedModule models.Module
@@ -103,7 +112,7 @@ func TestPATCHModule(t *testing.T) {
 		var newModActivityCount int64
 		config.Conn.Model(models.ModuleActivity{}).Where("module_id = ?", mockModule.ID).Count(&newModActivityCount)
 
-		if newModActivityCount == moduleActivityCount {
+		if newModActivityCount != (moduleActivityCount + 1) {
 			t.Errorf("did not create a new module activity")
 		}
 	})


### PR DESCRIPTION
## *Purpose:*
*What does this merge do? Check all that apply.*
- [ ] Adds a new endpoint
- [ ] Improves an existing endpoint
- [x] Fixes a bug
- [ ] Cleans up (documentation, tests, etc.)


## *Description: What does this PR do?*
*Briefly, but clearly describe what you did, and explain any new code.*
Fixes a bug in which patch requests for modules would create new module_activities instead of updating existing ones. This endpoint had previously assumed that these requests would include a module_activity id but (1) the module activity won't have an id if the module doesn't already have a module_activity for a specific activity, and (2) you can still create multiple module activities for a module with a given activity id. Rather than asking the front end to provide a data point that may or may not exist, it seemed easier to change the code to check for the existence of a module_activity based on module id and and activity id and then create or update accordingly.

## *What are the relevant tickets?*
Closes #59 


## *Bugs:*
*Are there any concerns, issues, or bugs in this branch? If so describe them.*


## Checklist:
- [x] I have reviewed my own code
- [x] New and existing tests pass locally with my change

## Database:
- [ ] This PR includes database changes